### PR TITLE
Use unicode that renders with many fonts

### DIFF
--- a/ui/components/issue/issue.go
+++ b/ui/components/issue/issue.go
@@ -65,9 +65,9 @@ func (issue *Issue) renderAssignees() string {
 
 func (issue *Issue) renderStatus() string {
 	if issue.Data.State == "OPEN" {
-		return lipgloss.NewStyle().Foreground(OpenIssue).Render("")
+		return lipgloss.NewStyle().Foreground(OpenIssue).Render("●")
 	} else {
-		return lipgloss.NewStyle().Foreground(OpenIssue).Render("")
+		return lipgloss.NewStyle().Foreground(OpenIssue).Render("●")
 	}
 }
 

--- a/ui/components/issue/styles.go
+++ b/ui/components/issue/styles.go
@@ -6,8 +6,8 @@ import (
 )
 
 var (
-	OpenIssue   = lipgloss.AdaptiveColor{Light: "#42A0FA", Dark: "#42A0FA"}
-	ClosedIssue = lipgloss.AdaptiveColor{Light: "#C38080", Dark: "#C38080"}
+	OpenIssue   = lipgloss.AdaptiveColor{Light: "#42A0FA", Dark: "#7FFF00"}
+	ClosedIssue = lipgloss.AdaptiveColor{Light: "#C38080", Dark: "#FF0000"}
 
 	titleText = lipgloss.NewStyle().Foreground(styles.DefaultTheme.PrimaryText)
 )

--- a/ui/components/issuessection/issuessection.go
+++ b/ui/components/issuessection/issuessection.go
@@ -91,14 +91,14 @@ func (m Model) Update(msg tea.Msg) (section.Section, tea.Cmd) {
 func GetSectionColumns() []table.Column {
 	return []table.Column{
 		{
-			Title: "",
+			Title: "⏰",
 			Width: &updatedAtCellWidth,
 		},
 		{
-			Title: "",
+			Title: "",
 		},
 		{
-			Title: "",
+			Title: "Repo",
 			Width: &issueRepoCellWidth,
 		},
 		{

--- a/ui/components/prssection/prssection.go
+++ b/ui/components/prssection/prssection.go
@@ -91,11 +91,12 @@ func (m Model) Update(msg tea.Msg) (section.Section, tea.Cmd) {
 func GetSectionColumns() []table.Column {
 	return []table.Column{
 		{
-			Title: "",
+                        // Updated
+			Title: "⏰",
 			Width: &updatedAtCellWidth,
 		},
 		{
-			Title: "",
+			Title: "Repo",
 			Width: &prRepoCellWidth,
 		},
 		{
@@ -118,7 +119,7 @@ func GetSectionColumns() []table.Column {
 			Width: &ciCellWidth,
 		},
 		{
-			Title: "",
+			Title: "🔢",
 			Width: &linesCellWidth,
 		},
 	}

--- a/ui/components/search/search.go
+++ b/ui/components/search/search.go
@@ -17,7 +17,7 @@ type Model struct {
 }
 
 func NewModel(sectionType string, ctx *context.ProgramContext, initialValue string) Model {
-	prompt := fmt.Sprintf(" is:%s ", sectionType)
+	prompt := fmt.Sprintf("is:%s ", sectionType)
 	ti := textinput.New()
 	ti.Placeholder = ""
 	ti.Focus()

--- a/ui/components/tabs/tabs.go
+++ b/ui/components/tabs/tabs.go
@@ -66,8 +66,8 @@ func (m *Model) renderViewSwitcher(ctx context.ProgramContext) string {
 		issuesStyle = activeView
 	}
 
-	prs := prsStyle.Render("[ PRs]")
-	issues := issuesStyle.Render("[ Issues]")
+	prs := prsStyle.Render("PRs]")
+	issues := issuesStyle.Render("[Issues]")
 	return viewSwitcher.Copy().
 		Render(lipgloss.JoinHorizontal(lipgloss.Top, prs, issues))
 }

--- a/ui/context/context.go
+++ b/ui/context/context.go
@@ -21,5 +21,5 @@ func (ctx *ProgramContext) GetViewSectionsConfig() []config.SectionConfig {
 		configs = ctx.Config.IssuesSections
 	}
 
-	return append([]config.SectionConfig{{Title: ""}}, configs...)
+	return append([]config.SectionConfig{{Title: "🐙"}}, configs...)
 }


### PR DESCRIPTION
I'm not going to patch my lovely https://fsd.it/shop/fonts/pragmatapro/ and I'd like to be able to understand what the column headers are, plus a variety of other unidentifiable unicodes.

![image](https://user-images.githubusercontent.com/118710/181838367-c8539568-b38e-4e11-97e1-c7973a2cd3f2.png)

![image](https://user-images.githubusercontent.com/118710/181838380-00e1fbc9-be0e-4301-a37b-69ad9a68af21.png)
